### PR TITLE
Small fix for extensions, plus litcoffee default

### DIFF
--- a/lib/sprockets_chain.js
+++ b/lib/sprockets_chain.js
@@ -1,4 +1,4 @@
-module.exports = (function() {
+module.exports = (function() { 
 
   var Trail    = require("hike").Trail,
       Resource = require("./sprockets_chain/resource");


### PR DESCRIPTION
appendExtensions function has a spelling error (_trail not _trails)

Also just putting litcoffee as a default extension.
