### PR TITLE
Fix CRLF end of lines breaking the parser.

### DIFF
--- a/lib/sprockets_chain/resource.js
+++ b/lib/sprockets_chain/resource.js
@@ -75,7 +75,7 @@ module.exports = (function() {
 
       header = (HEADER_PATTERN.exec( this.content() ) || []).shift() || '';
 
-      header.split("\n").forEach( function( line ) {
+      header.split(/\r?\n/).forEach( function( line ) {
         if ( match = DIRECTIVE_PATTERN.exec( line ) ) {
           results.push( match[1].trim() );
         }

--- a/spec/fixtures/bad_eoln.js
+++ b/spec/fixtures/bad_eoln.js
@@ -1,0 +1,3 @@
+
+//= require five/six/six
+//= require one

--- a/spec/sprockets_chain/resource.spec.js
+++ b/spec/sprockets_chain/resource.spec.js
@@ -13,6 +13,7 @@ describe("SprocketsChain", function() {
     this.trail = sc._trail;
     this.res   = new SprocketsChain.Resource( "one.js", sc._trail );
     this.res2  = new SprocketsChain.Resource( "two/two.js", sc._trail );
+    this.res3  = new SprocketsChain.Resource( "bad_eoln.js", sc._trail );
   });
 
   describe("SprocketsChain.Resource", function() {
@@ -97,6 +98,13 @@ describe("SprocketsChain", function() {
         expect( tree.dependencies[0].logical_path ).toEqual("four.js");
         expect( tree.dependencies[1].logical_path ).toEqual("one.js");
         expect( tree.dependencies[0].dependencies[0].logical_path ).toEqual("eight/eight.coffee");
+      });
+    });
+
+    describe("depTree", function() {
+      it("creates the dependency tree", function() {
+        var tree = this.res3.depTree();
+        expect( tree.dependencies[0].logical_path ).toEqual("five/six/six.js");
       });
     });
 


### PR DESCRIPTION
I had some files commited with `\r\n` end of line characters from other team members. The old regex choked on that.
