### PR TITLE
Handle Windows-style paths.

### DIFF
--- a/lib/sprockets_chain/resource.js
+++ b/lib/sprockets_chain/resource.js
@@ -37,9 +37,9 @@ module.exports = (function() {
     initialize: function( path, trail ) {
       this._trail       = trail;
       this.full_path    = fullPath( path, trail );
-
+      
       // Add extension to logical path
-      var split         = this.full_path.split( path );
+      var split         = this.full_path.replace(/\\/g, '/').split( path );
       this.logical_path = path + split[ split.length - 1 ];
     },
 
@@ -47,7 +47,7 @@ module.exports = (function() {
     resolve: function( path ) {
       if ( isRelative( path ) ) {
         var dir = _path.dirname( this.logical_path );
-        return _path.join( dir, path );
+        return _path.join( dir, path ).replace(/\\/g, '/');
       }
       return path;
     },

--- a/spec/sprockets_chain/resource.spec.js
+++ b/spec/sprockets_chain/resource.spec.js
@@ -28,6 +28,55 @@ describe("SprocketsChain", function() {
         var res = new SprocketsChain.Resource( "one", this.trail );
         expect( res.logical_path ).toEqual( "one.js" );
       });
+      
+      describe("Windows paths", function() {
+        var mockPath;
+        var mockTrail;
+        
+        beforeEach(function(){
+          mockTrail = {
+            find: function(logical_path){
+              return mockPath;
+            }
+          };
+        });
+        
+        describe("simple resource path", function(){
+          beforeEach(function(){
+            mockPath = "c:\\Users\\MockUser\\sprockets-chain\\spec\\fixtures\\one.js";
+          });
+          
+          it("sets the correct full path with Windows separators", function(){
+            var res = new SprocketsChain.Resource( "one.js", mockTrail );
+            expect( res.full_path ).toEqual( "c:\\Users\\MockUser\\sprockets-chain\\spec\\fixtures\\one.js" );
+            expect( res.logical_path ).toEqual( "one.js" );
+          });
+
+          it("sets the correct logical path with extension with Windows separators", function() {
+            var res = new SprocketsChain.Resource( "one", mockTrail );
+            expect( res.full_path ).toEqual( "c:\\Users\\MockUser\\sprockets-chain\\spec\\fixtures\\one.js" );
+            expect( res.logical_path ).toEqual( "one.js" );
+          });
+        });
+        
+        describe("complex resource path", function(){
+          beforeEach(function(){
+            mockPath = "c:\\Users\\MockUser\\sprockets-chain\\spec\\fixtures\\two\\two.js";
+          });
+          
+          it("sets the correct full path with Windows separators", function(){
+            var res = new SprocketsChain.Resource( "two/two.js", mockTrail );
+            expect( res.full_path ).toEqual( "c:\\Users\\MockUser\\sprockets-chain\\spec\\fixtures\\two\\two.js" );
+            expect( res.logical_path ).toEqual( "two/two.js" );
+          });
+          
+          it("sets the logical path extension with Windows separators", function(){
+            var res = new SprocketsChain.Resource( "two/two", mockTrail );
+            expect( res.full_path ).toEqual( "c:\\Users\\MockUser\\sprockets-chain\\spec\\fixtures\\two\\two.js" );
+            expect( res.logical_path ).toEqual( "two/two.js" );
+          });
+        });
+      });
     });
 
     describe("resolve", function() {


### PR DESCRIPTION
Hi,

I ran into trouble on Windows and found that the `logical_path` was evaluating to odd values because of the different path separator.

This change replaces the backslash with slashes when converting the file system path to logical path.

I've added tests for these cases (where possible) - this only changes the path on Windows, Unix-style paths aren't affected.
