### PR TITLE
Make require_directory only include certain extensions

### DIFF
--- a/lib/sprockets_chain/resource.js
+++ b/lib/sprockets_chain/resource.js
@@ -152,10 +152,14 @@ module.exports = (function() {
       var self_dir = _path.dirname( this.logical_path ),
           full_dir = _path.join( _path.dirname( this.full_path ), dir ),
           entries  = this._trail.entries( full_dir ),
-          paths    = [];
+          paths    = [],
+          self     = this;
 
       entries.forEach(function( e ) {
         if ( _fs.statSync( _path.join( full_dir, e ) ).isFile() ) {
+          if (self._trail.extensions.toArray().indexOf(_path.extname(e)) == -1) {
+            return;
+          }
           paths.push( normalizePath( _path.join( self_dir, dir, e ) ) );
         }
       });


### PR DESCRIPTION
If there's an arbitrary file, such as a `README.md`, in a directory (for example, including `bower` components), then `require_directory` will include it. This breaks builds. The fix is really easy, though — this is already explicitly checked for in `require_tree`, but not `require_directory`.

This PR adds the necessary check to `require_directory` and updates the tests.