### PR TITLE
Add support for 'stub' directive

### DIFF
--- a/lib/sprockets_chain/resource.js
+++ b/lib/sprockets_chain/resource.js
@@ -64,6 +64,40 @@ module.exports = (function() {
   function normalizePath( path ){
     return path.replace(/\\/g, '/');
   }
+  
+  /*
+  For the list of dependencies, `deps`, return a map of paths merged
+  with parent stubs that have been stubbed out for quick lookup later.
+    
+  Only ancestor files can stub out children - siblings can't stub
+  each other out.
+  */
+  function collectStubs( deps, parentStubs ){
+    var stubs;
+    
+    if ( typeof parentStubs !== "object" ) {
+      parentStubs = {};
+    }
+    
+    // Check each directive 
+    deps.forEach(function(d){
+      if ( d.require_directive === "stub" ){
+        if ( !stubs ){
+          // Only create a new object if we have stubbed assets at this level.
+          // This avoids a long prototype chain of empty objects.
+          stubs = Object.create( parentStubs );
+        }
+        stubs[d.full_path] = true;
+      }
+    });
+    
+    // If we don't have any stubs at this level then just return `parentStubs`.
+    if ( !stubs ){
+      stubs = parentStubs;
+    }
+    
+    return stubs;
+  }
 
   // Resource constructor
   var Resource = function Resource() {
@@ -129,7 +163,7 @@ module.exports = (function() {
       var requires = this.parseRequires(),
           deps     = [],
           self     = this;
-
+      
       requires.forEach(function( r ) {
         var a         = r.match(/(\w+)(?:\s+(["']?)(.*)\2)?/),
             directive = a[1],
@@ -138,6 +172,7 @@ module.exports = (function() {
         switch( directive ) {
           case "require":
           case "include":
+          case "stub":
             deps.push({
               directive: directive,
               path:      self.resolve( required )
@@ -244,15 +279,17 @@ module.exports = (function() {
     // Return the dependency chain of this resource, which is an array of the
     // file paths of all the dependency of this resource plus this resource
     // itself, ordered so that every file is preceded by all its dependencies.
-    depChain: function( chain ) {
+    depChain: function( chain, parentStubs ) {
       var deps  = this.depTree().dependencies,
+          stubs = collectStubs( deps, parentStubs ),
           already_added = false,
           self = this;
 
       if ( !Array.isArray( chain ) ) {
         chain = [];
       }
-
+      
+      function isStubbed(d){ return stubs[d.full_path] != null; }
       function isSelf(d) { return d.full_path === self.full_path }
       function addSelf() {
         if ( self.require_directive === "include" || !contains( chain, self.full_path ) ) {
@@ -261,10 +298,12 @@ module.exports = (function() {
       }
 
       deps.forEach(function( d ) {
-        if ( !isSelf(d) && !contains(chain, d.full_path) ) {
-          d.depChain( chain );
+        if (isStubbed(d)){
+          // skip this resource and it's children
+        } else if ( !isSelf(d) && !contains(chain, d.full_path) ) {
+          d.depChain( chain, stubs );
         } else if ( d.require_directive === "include" ) {
-          d.depChain( chain );
+          d.depChain( chain, stubs );
         } else if( isSelf(d) ){
           addSelf();
           already_added = true;

--- a/spec/fixtures/one.js
+++ b/spec/fixtures/one.js
@@ -4,3 +4,4 @@
 *= require_directory ./two
 */
 //= require_tree ./five
+//= stub ./five/six/eight-stub

--- a/spec/sprockets_chain/resource.spec.js
+++ b/spec/sprockets_chain/resource.spec.js
@@ -142,15 +142,17 @@ describe("SprocketsChain", function() {
     describe("parseDeps", function() {
       it("returns all dependencies, with logical path and directive", function() {
         this.stub( this.res, "parseRequires", function() {
-          return ["require four", "require_self", "require_directory ./two", "require_tree ./five"];
+          return ["require four", "require_self", "require_directory ./two", "require_tree ./five", "stub ./five/six/eight-stub"];
         });
         expect( this.res.parseDeps() ).toEqual([
           { path: "four",                     directive: "require" },
           { path: "one.js",                   directive: "require_self" },
           { path: "two/three.coffee",         directive: "require_directory" },
           { path: "two/two.js",               directive: "require_directory" },
+          { path: "five/six/eight-stub.js",   directive: "require_tree" },
           { path: "five/six/seven.js.coffee", directive: "require_tree" },
-          { path: "five/six/six.js",          directive: "require_tree" }
+          { path: "five/six/six.js",          directive: "require_tree" },
+          { path: "five/six/eight-stub",      directive: "stub" }
         ]);
       });
 


### PR DESCRIPTION
Implements the [Sprockets `stub` directive](https://github.com/rails/sprockets#the-stub-directive) so assets can be excluded from a resource chain.

**Example**

With this directory structure:

```
root/
├─ index.js
└─ a/
   ├─ one.js
   └─ b/
      ├─ two.js
      └─ three.js
```

and this content in `index.js`:

```
/* index.js */
//= require_tree ./a
//= stub a/b/two
```

The resource chain for `index.js` will include these files.

```
a/one.js
a/b/three.js
```

Note that `a/b/two.js` has been excluded by the `stub` directive.
