### PR TITLE
require_tree: handle paths across different root directories

### DIFF
--- a/lib/sprockets_chain/resource.js
+++ b/lib/sprockets_chain/resource.js
@@ -198,7 +198,7 @@ module.exports = (function() {
     },
 
     // Return an array of logical paths of all the files in a directory tree,
-    // specified by its path relative to this resource
+    // specified by its path relative to this resource or root directory
     pathsInTree: function( dir ) {
       var self_dir = _path.dirname( this.logical_path ),
           full_dir = _path.join( _path.dirname( this.full_path ), dir ),
@@ -211,7 +211,23 @@ module.exports = (function() {
           if (self._trail.extensions.toArray().indexOf(_path.extname(e)) == -1) {
             return;
           }
-          paths.push( normalizePath( _path.join( self_dir, dir, e ) ) );
+          
+          // Find the root path that contains the requested directory.
+          var curFullPath = _path.join( full_dir, e )
+          var newRoot = self._trail.paths.toArray().find(function(basePath){
+            return curFullPath.indexOf(basePath) == 0;
+          });
+          
+          var finalPath;
+          if (newRoot){
+            // Get the remaining path relative to the Sprockets root.
+            finalPath = _path.relative(newRoot, curFullPath);
+          } else {
+            // Otherwise fallback to the original path behaviour.
+            finalPath = _path.join( self_dir, dir, e );
+          }
+          
+          paths.push( normalizePath( finalPath ) );
         } else {
           paths = paths.concat( self.pathsInTree( _path.join( dir, e ) ) );
         }
@@ -219,6 +235,7 @@ module.exports = (function() {
 
       return paths;
     },
+
 
     // Build and return the dependency tree of this resource
     depTree: function() {

--- a/spec/fixtures4/assets/sub1/one.js
+++ b/spec/fixtures4/assets/sub1/one.js
@@ -1,0 +1,2 @@
+//= require_tree ./../../vendor/sub2
+

--- a/spec/sprockets_chain.spec.js
+++ b/spec/sprockets_chain.spec.js
@@ -1,4 +1,5 @@
-var buster         = require("buster"),
+var _path          = require("path"),
+    buster         = require("buster"),
     SprocketsChain = require("../lib/sprockets_chain"),
     expect         = buster.referee.expect;
 
@@ -37,4 +38,28 @@ describe("SprocketsChain", function() {
     });
   });
 
+});
+
+
+describe("require_tree across paths", function(){
+  
+  before(function(){
+    this.sc = new SprocketsChain();
+    this.sc.appendPath("spec/fixtures4/assets");
+    this.sc.appendPath("spec/fixtures4/vendor");
+  });
+  
+  
+  it("resolves require_tree directories relative to root directory", function(){
+    // Note: order of paths is reversed because dependencies are
+    // output first before the original file.
+    var expectedPaths = [
+      _path.resolve("./spec/fixtures4/", "vendor/sub2/two.js"),
+      _path.resolve("./spec/fixtures4/", "assets/sub1/one.js")
+    ];
+    
+    var result = this.sc.depChain('sub1/one.js');
+    expect(result).toEqual(expectedPaths);
+  });
+  
 });


### PR DESCRIPTION
Hi, this one is a little bit complex but I'll try to explain.

I have encountered this issue in production code.

This PR updates the `resource.pathsInTree()` behaviour to allow `require_tree` to handle paths that span across multiple root directories.


__Example__

Given this directory structure:

```
root/
 ├─ assets/
 |  └─ sub1/
 |     └─ one.js
 └─ vendor/
    └─ sub2/
       └─ two.js
```

and this logical structure where "sub1/" and "sub2/" don't share a common parent under the SprocketsChain logical root.

```
var sc = new SprocketsChain();
sc.appendPath("root/assets");
sc.appendPath("root/vendor");

[SprocketsChain logical_root/]
 ├─ sub1/
 |  └─ one.js
 └─ sub2/
    └─ two.js
```

"sub1/one.js" wants to `require_tree` the "sub2/" directory.

```
/* sub1/one.js */
//= require_tree ./../../vendor/sub2
```


__Previous behaviour__

Currently SprocketsChain tries to resolve "sub2/" relative to the __current__ "sub1/one.js" file.

Trying to do this:

```
path.resolve("root/assets/sub1/one.js", "../vendor/sub2/two.js")
```

and would fail with an invalid path:

```
// Invalid - not a file on disk
"root/assets/vendor/sub2/two.js"
```


__New behaviour__

This PR updates `pathsInTree()` to resolve the path relative to the __root directory__ that contains the requested directory.

i.e. Resolves "sub2/" relative to the on-disk "root/vendor/" directory

```
path.resolve("root/vendor", "sub2/two.js")
```

```
// Yay, correct path
"root/vendor/sub2/two.js"
```

I've added a test under `spec/fixtures4`.

All the previous `require_tree` cases continue to work, this just adds support for requiring across different root directories.
